### PR TITLE
some people might put a space in btween the ){

### DIFF
--- a/FourThingsToLearnPowerShell/Start-Demo.ps1
+++ b/FourThingsToLearnPowerShell/Start-Demo.ps1
@@ -103,7 +103,7 @@ NOTE: Start-Demo replaces the typing but runs the actual commands.
  
     } # else
 
-    if(($_lines[$_i] -match '\)' -and $_lines[$_i+1] -match '\{') -or ($_lines[$_i] -match '\){'))
+    if(($_lines[$_i] -match '\)' -and $_lines[$_i+1] -match '\{') -or ($_lines[$_i] -match '\)\s?{'))
     {
         $justKeepSwinging++
     }

--- a/Start-Demo.ps1
+++ b/Start-Demo.ps1
@@ -103,7 +103,7 @@ NOTE: Start-Demo replaces the typing but runs the actual commands.
  
     } # else
 
-    if(($_lines[$_i] -match '\)' -and $_lines[$_i+1] -match '\{') -or ($_lines[$_i] -match '\){'))
+    if(($_lines[$_i] -match '\)' -and $_lines[$_i+1] -match '\{') -or ($_lines[$_i] -match '\)\s?{'))
     {
         $justKeepSwinging++
     }


### PR DESCRIPTION
just found something when I was setting up a demo,

i was doing 
if($this -eq 1) {
    "Do this"
}

and it then errored because we hadnt included that in the pattern match.
